### PR TITLE
Add api users from admin interface

### DIFF
--- a/hacktester/api_auth/admin.py
+++ b/hacktester/api_auth/admin.py
@@ -7,6 +7,10 @@ class ApiUserAdmin(admin.ModelAdmin):
     list_display = ('host', 'key')
     readonly_fields = ('secret', 'key')
 
+    def save_model(self, request, obj, form, change):
+        obj = ApiUser.create_api_user(form.cleaned_data.get('host'))
+        obj.save()
+
 
 @admin.register(ApiRequest)
 class ApiRequestAdmin(admin.ModelAdmin):

--- a/hacktester/api_auth/admin.py
+++ b/hacktester/api_auth/admin.py
@@ -5,7 +5,7 @@ from .models import ApiUser, ApiRequest
 @admin.register(ApiUser)
 class ApiUserAdmin(admin.ModelAdmin):
     list_display = ('host', 'key')
-    readonly_fields = ('secret', 'key')
+    readonly_fields = ('key', 'secret')
 
     def save_model(self, request, obj, form, change):
         obj = ApiUser.create_api_user(form.cleaned_data.get('host'))

--- a/hacktester/api_auth/admin.py
+++ b/hacktester/api_auth/admin.py
@@ -9,7 +9,7 @@ class ApiUserAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         obj = ApiUser.create_api_user(form.cleaned_data.get('host'))
-        obj.save()
+        return obj
 
 
 @admin.register(ApiRequest)

--- a/hacktester/api_auth/management/commands/create_api_user.py
+++ b/hacktester/api_auth/management/commands/create_api_user.py
@@ -12,6 +12,5 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         host = options['host']
         user = ApiUser.create_api_user(host=host)
-        user.save()
         self.stdout.write("Key: {}".format(user.key))
         self.stdout.write("Secret: {}".format(user.secret))

--- a/hacktester/api_auth/models.py
+++ b/hacktester/api_auth/models.py
@@ -15,7 +15,7 @@ class ApiUser(models.Model):
         key = generate_random_key(host)
         secret = generate_random_key(host)
 
-        return ApiUser(host=host, key=key, secret=secret)
+        return ApiUser.objects.create(host=host, key=key, secret=secret)
 
 
 class ApiRequest(models.Model):

--- a/hacktester/api_auth/tests/test_admin.py
+++ b/hacktester/api_auth/tests/test_admin.py
@@ -1,0 +1,22 @@
+from test_plus import TestCase
+
+from django.contrib.auth.models import User
+
+from hacktester.api_auth.models import ApiUser
+
+
+class TestAdminApiUserCreation(TestCase):
+    def setUp(self):
+        self.test_password = 'testpassword'
+        self.user = User.objects.create_superuser(username="admin",
+                                                  email="admin@admin.com",
+                                                  password=self.test_password)
+        self.url = self.reverse('admin:api_auth_apiuser_add')
+
+    def test_api_user_is_created_correctly_on_post_to_admin_creation_page(self):
+        api_user_count = ApiUser.objects.count()
+        with self.login(username=self.user.username, password=self.test_password):
+            data = {'host': 'exampleurl.com'}
+            response = self.post(self.url, data=data)
+            self.response_302(response)
+            self.assertEqual(api_user_count + 1, ApiUser.objects.count())


### PR DESCRIPTION
Add the ability to create api users from the django admin page instead of running a manage.py command